### PR TITLE
Add "--test_set custom" option

### DIFF
--- a/easse/cli.py
+++ b/easse/cli.py
@@ -7,11 +7,38 @@ from easse.utils.helpers import read_lines
 from easse.quality_estimation import corpus_quality_estimation
 from easse.sari import corpus_sari
 from easse.samsa import corpus_samsa
-from easse.utils.resources import (get_turk_orig_sents, get_turk_refs_sents,
-                                   get_pwkp_orig_sents, get_pwkp_refs_sents,
-                                   get_hsplit_orig_sents, get_hsplit_refs_sents)
-from easse.utils.constants import VALID_TEST_SETS, VALID_METRICS, DEFAULT_METRICS
+from easse.utils.constants import VALID_TEST_SETS, VALID_METRICS, DEFAULT_METRICS, TEST_SETS_PATHS
 from easse.report import write_html_report
+
+
+def get_sents(test_set, orig_sents_path=None, sys_sents_path=None, refs_sents_paths=None):
+    if sys_sents_path is not None:
+        sys_sents = read_lines(sys_sents_path)
+    else:
+        # read the system output
+        with click.get_text_stream('stdin', encoding='utf-8') as system_output_file:
+            sys_sents = system_output_file.read().splitlines()
+
+    if type(refs_sents_paths) == str:
+        refs_sents_paths = refs_sents_paths.split(',')
+
+    if test_set != 'custom':
+        assert orig_sents_path is None
+        assert refs_sents_paths is None
+        orig_sents_path = TEST_SETS_PATHS[(test_set, 'orig')]
+        refs_sents_paths = TEST_SETS_PATHS[(test_set, 'refs')]
+    assert orig_sents_path is not None
+    assert refs_sents_paths is not None
+    orig_sents = read_lines(orig_sents_path)
+    refs_sents = [read_lines(ref_sents_path) for ref_sents_path in refs_sents_paths]
+    assert len(sys_sents) == len(orig_sents)
+    assert all([len(sys_sents) == len(ref_sents) for ref_sents in refs_sents])
+    return orig_sents, sys_sents, refs_sents
+
+
+def is_test_set_lowercase(test_set):
+    # TODO: Handle case where test set is custom
+    return test_set in ['pwkp', 'pwkp_valid', 'hsplit']
 
 
 @click.group(context_settings={'help_option_names': ['-h', '--help']})
@@ -26,8 +53,16 @@ def common_options(function):
             help='test set to use.',
     )(function)
     function = click.option(
-            '--input_path', '-i', type=click.Path(), default=None,
+            '--sys_sents_path', type=click.Path(), default=None,
             help='Path to the system predictions input file that is to be evaluated.',
+    )(function)
+    function = click.option(
+            '--orig_sents_path', type=click.Path(), default=None,
+            help='Path to the source sentences. Only used when test_set == "custom"',
+    )(function)
+    function = click.option(
+            '--refs_sents_paths', type=str, default=None,
+            help='Comma-separated list of path(s) to the references(s). Only used when test_set == "custom"',
     )(function)
     function = click.option(
             '--tokenizer', '-tok', type=click.Choice(['13a', 'intl', 'moses', 'plain']), default='13a',
@@ -53,7 +88,9 @@ def _evaluate_system_output(*args, **kwargs):
 
 def evaluate_system_output(
         test_set,
-        input_path=None,
+        sys_sents_path=None,
+        orig_sents_path=None,
+        refs_sents_paths=None,
         tokenizer='13a',
         metrics=','.join(VALID_METRICS),
         analysis=False,
@@ -62,75 +99,38 @@ def evaluate_system_output(
     """
     Evaluate a system output with automatic metrics.
     """
-    if input_path is not None:
-        sys_output = read_lines(input_path)
-    else:
-        # read the system output
-        with click.get_text_stream('stdin', encoding='utf-8') as system_output_file:
-            sys_output = system_output_file.read().splitlines()
-
     # get the metrics that need to be computed
     metrics = metrics.split(',')
-
-    load_orig_sents = ('sari' in metrics) or ('samsa' in metrics) or analysis or quality_estimation
-    load_refs_sents = ('sari' in metrics) or ('bleu' in metrics) or analysis
-    # get the references from the test set
-    if test_set in ['turk', 'turk_valid']:
-        lowercase = False
-        phase = 'test' if test_set == 'turk' else 'valid'
-        if load_orig_sents:
-            orig_sents = get_turk_orig_sents(phase=phase)
-        if load_refs_sents:
-            refs_sents = get_turk_refs_sents(phase=phase)
-
-    if test_set in ['pwkp', 'pwkp_valid']:
-        lowercase = True
-        phase = 'test' if test_set == 'pwkp' else 'valid'
-        if load_orig_sents:
-            orig_sents = get_pwkp_orig_sents(phase=phase)
-        if load_refs_sents:
-            refs_sents = get_pwkp_refs_sents(phase=phase)
-
-    if test_set == 'hsplit':
-        sys_output = sys_output[:70]
-        lowercase = True
-        if load_orig_sents:
-            orig_sents = get_hsplit_orig_sents()
-        if load_refs_sents:
-            refs_sents = get_hsplit_refs_sents()
-
-    if load_orig_sents:
-        assert len(sys_output) == len(orig_sents)
-    if load_refs_sents:
-        assert len(sys_output) == len(refs_sents[0])
+    orig_sents, sys_sents, refs_sents = get_sents(test_set, orig_sents_path, sys_sents_path, refs_sents_paths)
+    lowercase = is_test_set_lowercase(test_set)
 
     # compute each metric
     if 'bleu' in metrics:
-        bleu_score = sacrebleu.corpus_bleu(sys_output, refs_sents,
+        bleu_score = sacrebleu.corpus_bleu(sys_sents, refs_sents,
                                            force=True, tokenize=tokenizer, lowercase=lowercase).score
         click.echo(f'BLEU: {bleu_score:.2f}')
 
     if 'sari' in metrics:
-        sari_score = corpus_sari(orig_sents, sys_output, refs_sents, tokenizer=tokenizer, lowercase=lowercase)
+        sari_score = corpus_sari(orig_sents, sys_sents, refs_sents, tokenizer=tokenizer, lowercase=lowercase)
         click.echo(f'SARI: {sari_score:.2f}')
 
     if 'samsa' in metrics:
-        samsa_score = corpus_samsa(orig_sents, sys_output, tokenizer=tokenizer, verbose=True, lowercase=lowercase)
+        samsa_score = corpus_samsa(orig_sents, sys_sents, tokenizer=tokenizer, verbose=True, lowercase=lowercase)
         click.echo(f'SAMSA: {samsa_score:.2f}')
 
     if 'fkgl' in metrics:
-        fkgl_score = corpus_fkgl(sys_output, tokenizer=tokenizer)
+        fkgl_score = corpus_fkgl(sys_sents, tokenizer=tokenizer)
         click.echo(f'FKGL: {fkgl_score:.2f}')
 
     if analysis:
-        word_level_analysis = corpus_analyse_operations(orig_sents, sys_output, refs_sents,
+        word_level_analysis = corpus_analyse_operations(orig_sents, sys_sents, refs_sents,
                                                         verbose=False, as_str=True)
         click.echo(f'Word-level Analysis: {word_level_analysis}')
 
     if quality_estimation:
         quality_estimation_scores = corpus_quality_estimation(
                 orig_sents,
-                sys_output,
+                sys_sents,
                 tokenizer=tokenizer,
                 lowercase=lowercase
                 )
@@ -146,27 +146,21 @@ def _report(*args, **kwargs):
     report(*args, **kwargs)
 
 
-def report(test_set, input_path=None, report_path='report.html', tokenizer='13a', metrics=','.join(DEFAULT_METRICS)):
+def report(
+        test_set,
+        sys_sents_path=None,
+        orig_sents_path=None,
+        refs_sents_paths=None,
+        report_path='report.html',
+        tokenizer='13a',
+        metrics=','.join(DEFAULT_METRICS)
+        ):
     """
     Create a HTML report file with automatic metrics, plots and samples.
     """
-    if input_path is not None:
-        sys_output = read_lines(input_path)
-    else:
-        # read the system output
-        with click.get_text_stream('stdin', encoding='utf-8') as system_output_file:
-            sys_output = system_output_file.read().splitlines()
-    if test_set in ['turk', 'turk_valid']:
-        lowercase = False
-        phase = 'test' if test_set == 'turk' else 'valid'
-        refs_sents = get_turk_refs_sents(phase=phase)
-        orig_sents = get_turk_orig_sents(phase=phase)
-    if test_set == 'hsplit':
-        sys_output = sys_output[:70]
-        lowercase = True
-        refs_sents = get_hsplit_refs_sents()
-        orig_sents = get_hsplit_orig_sents()
+    orig_sents, sys_sents, refs_sents = get_sents(test_set, orig_sents_path, sys_sents_path, refs_sents_paths)
+    lowercase = is_test_set_lowercase(test_set)
     write_html_report(
-            report_path, orig_sents, sys_output, refs_sents, test_set_name=test_set,
+            report_path, orig_sents, sys_sents, refs_sents, test_set_name=test_set,
             lowercase=lowercase, tokenizer=tokenizer, metrics=metrics,
             )

--- a/easse/resources/data/test_sets/hsplit/hsplit.tok.src
+++ b/easse/resources/data/test_sets/hsplit/hsplit.tok.src
@@ -1,0 +1,70 @@
+one side of the armed conflicts is composed mainly of the sudanese military and the janjaweed , a sudanese militia group recruited mostly from the afro-arab abbala tribes of the northern rizeigat region in sudan .
+jeddah is the principal gateway to mecca , islam 's holiest city , which able-bodied muslims are required to visit at least once in their lifetime .
+the great dark spot is thought to represent a hole in the methane cloud deck of neptune .
+his next work , saturday , follows an especially eventful day in the life of a successful neurosurgeon .
+the tarantula , the trickster character , spun a black cord and , attaching it to the ball , crawled away fast to the east , pulling on the cord with all his strength .
+there he died six weeks later , on 13 january 888 .
+they are culturally akin to the coastal peoples of papua new guinea .
+since 2000 , the recipient of the kate greenaway medal has also been presented with the colin mears award to the value of £ 5000 .
+following the drummers are dancers , who often play the sogo -lrb- a tiny drum that makes almost no sound -rrb- and tend to have more elaborate — even acrobatic — choreography .
+the spacecraft consists of two main elements : the nasa cassini orbiter , named after the italian-french astronomer giovanni domenico cassini , and the esa huygens probe , named after the dutch astronomer , mathematician and physicist christiaan huygens .
+alessandro -lrb- " sandro " -rrb- mazzola -lrb- born 8 november 1942 -rrb- is an italian former football player .
+it was originally thought that the debris thrown up by the collision filled in the smaller craters .
+graham attended wheaton college from 1939 to 1943 , when he graduated with a ba in anthropology .
+however , the bzö differs a bit in comparison to the freedom party , as is in favor of a referendum about the lisbon treaty but against an eu-withdrawal .
+many species had vanished by the end of the nineteenth century , with european settlement .
+in 1987 wexler was inducted into the rock and roll hall of fame .
+in its pure form , dextromethorphan occurs as a white powder .
+admission to tsinghua is extremely competitive .
+today nrc is organised as an independent , private foundation .
+it is situated at the coast of the baltic sea , where it encloses the city of stralsund .
+he was also named 1982 " sportsman of the year " by sports illustrated .
+fives is a british sport believed to derive from the same origins as many racquet sports .
+for example , king bhumibol was born on monday , so on his birthday throughout thailand will be decorated with yellow color .
+both names became defunct in 2007 when they were merged into the national museum of scotland .
+nevertheless , tagore emulated numerous styles , including craftwork from northern new ireland , haida carvings from the west coast of canada -lrb- british columbia -rrb- , and woodcuts by max pechstein .
+on october 14 , 1960 , presidential candidate john f. kennedy proposed the concept of what became the peace corps on the steps of michigan union .
+she performed for president reagan in 1988 's great performances at the white house series , which aired on the public broadcasting service .
+perry saturn -lrb- with terri -rrb- defeated eddie guerrero -lrb- with chyna -rrb- to win the wwf european championship -lrb- 8:10 -rrb- saturn pinned guerrero after a diving elbow drop .
+she remained in the united states until 1927 when she and her husband returned to france .
+despina was discovered in late july , 1989 from the images taken by the voyager 2 probe .
+the first italian grand prix motor racing championship took place on 4 september 1921 at brescia .
+he also completed two collections of short stories entitled the ribbajack & other curious yarns and seven strange and ghostly tales .
+at the voyager 2 images ophelia appears as an elongated object , the major axis pointing towards uranus .
+the british decided to eliminate him and take the land by force .
+some towns on the eyre highway in the south-east corner of western australia , between the south australian border almost as far as caiguna , do not follow official western australian time .
+in architectural decoration small pieces of colored and iridescent shell have been used to create mosaics and inlays , which have been used to decorate walls , furniture and boxes .
+the other incorporated cities on the palos verdes peninsula include rancho palos verdes , rolling hills estates and rolling hills .
+fearing that drek will destroy the galaxy , clank asks ratchet to help him find the famous superhero captain qwark , in an effort to stop drek .
+it is not actually a true louse .
+he advocates applying a user-centered design process in product development cycles and also works towards popularizing interaction design as a mainstream discipline .
+it is theoretically possible that the other editors who may have reported you , and the administrator who blocked you , are part of a conspiracy against someone half a world away they ' ve never met in person .
+working group i : assesses scientific aspects of the climate system and climate change .
+the island chain forms part of the hebrides , separated from the scottish mainland and from the inner hebrides by the stormy waters of the minch , the little minch and the sea of the hebrides .
+orton and his wife welcomed alanna marie orton on july 12 , 2008 .
+formal minor planet designations are number-name combinations overseen by the minor planet center , a branch of the iau .
+by early on september 30 , wind shear began to dramatically increase and a weakening trend began .
+each entry has a datum -lrb- a nugget of data -rrb- which is a copy of the datum in some backing store .
+as a result , although many mosques will not enforce violations , both men and women when attending a mosque must adhere to these guidelines .
+mariel of redwall is a fantasy novel by brian jacques , published in 1991 .
+ryan prosser -lrb- born 10 july , 1988 -rrb- is a professional rugby union player for bristol rugby in the guinness premiership .
+like previous assessment reports , it consists of four reports , three of them from its working groups .
+their granddaughter hélène langevin-joliot is a professor of nuclear physics at the university of paris , and their grandson pierre joliot , who was named after pierre curie , is a noted biochemist .
+this stamp remained the standard letter stamp for the remainder of victoria 's reign , and vast quantities were printed .
+the international fight league was an american mixed martial arts -lrb- mma -rrb- promotion billed as the world 's first mma league .
+giardia lamblia -lrb- synonymous with lamblia intestinalis and giardia duodenalis -rrb- is a flagellated protozoan parasite that colonises and reproduces in the small intestine , causing giardiasis .
+aside from this , cameron has often worked in christian-themed productions , among them the post-rapture films left behind : the movie , left behind ii : tribulation force , and left behind : world at war , in which he plays cameron " buck " williams .
+this was the area east of the mouth of the vistula river , later sometimes called " prussia proper " .
+after graduation he returned to yerevan to teach at the local conservatory and later he was appointed artistic director of the armenian philarmonic orchestra .
+the story of christmas is based on the biblical accounts given in the gospel of matthew , namely - and the gospel of luke , specifically - .
+weelkes was later to find himself in trouble with the chichester cathedral authorities for his heavy drinking and immoderate behaviour .
+so far the ' celebrity ' episodes have included vic reeves , nancy sorrell , gaby roslin , scott mills , mark chapman , simon gregson , sue cleaver , carol thatcher , paul o ' grady and lee ryan .
+it was discovered by stephen p. synnott in images from the voyager 1 space probe taken on march 5 , 1979 while orbiting around jupiter .
+gomaespuma was a spanish radio show , hosted by juan luis cano and guillermo fesser .
+on 16 june 2009 , the official release date of the resistance was announced on the band 's website .
+he is also a member of another jungiery boyband 183 club .
+the apostolic tradition , attributed to the theologian hippolytus , attests the singing of hallel psalms with alleluia as the refrain in early christian agape feasts .
+in return , rollo swore fealty to charles , converted to christianity , and undertook to defend the northern region of france against the incursions of other viking groups .
+it is derived from voice of america -lrb- voa -rrb- special english .
+disney received a full-size oscar statuette and seven miniature ones , presented to him by 10-year-old child actress shirley temple .
+it was the first asteroid to be discovered by a spacecraft .

--- a/easse/utils/constants.py
+++ b/easse/utils/constants.py
@@ -9,8 +9,20 @@ DATA_DIR = RESOURCES_DIR / 'data'
 STANFORD_CORENLP_DIR = TOOLS_DIR / 'stanford-corenlp-full-2018-10-05'
 UCCA_DIR = TOOLS_DIR / 'ucca-bilstm-1.3.10'
 UCCA_PARSER_PATH = UCCA_DIR / 'models/ucca-bilstm'
+TEST_SETS_PATHS = {
+        ('turk', 'orig'): DATA_DIR / f'test_sets/turk/test.8turkers.tok.norm',
+        ('turk', 'refs'): [DATA_DIR / f'test_sets/turk/test.8turkers.tok.turk.{i}' for i in range(8)],
+        ('turk_valid', 'orig'): DATA_DIR / f'test_sets/turk/tune.8turkers.tok.norm',
+        ('turk_valid', 'refs'): [DATA_DIR / f'test_sets/turk/tune.8turkers.tok.turk.{i}' for i in range(8)],
+        ('pwkp', 'orig'): DATA_DIR / f'test_sets/pwkp/pwkp.test.src',
+        ('pwkp', 'refs'): [DATA_DIR / f'test_sets/pwkp/pwkp.test.dst'],
+        ('pwkp_valid', 'orig'): DATA_DIR / f'test_sets/pwkp/pwkp.valid.src',
+        ('pwkp_valid', 'refs'): [DATA_DIR / f'test_sets/pwkp/pwkp.valid.dst'],
+        ('hsplit', 'orig'): DATA_DIR / f'test_sets/hsplit/hsplit.tok.src',
+        ('hsplit', 'refs'): [DATA_DIR / f'test_sets/hsplit/hsplit.tok.{i+1}' for i in range(4)],
+}
 
 # Constants
-VALID_TEST_SETS = ['turk', 'turk_valid', 'pwkp', 'pwkp_valid', 'hsplit']
+VALID_TEST_SETS = ['turk', 'turk_valid', 'pwkp', 'pwkp_valid', 'hsplit', 'custom']
 VALID_METRICS = ['bleu', 'sari', 'samsa', 'fkgl']
 DEFAULT_METRICS = [m for m in VALID_METRICS if m != 'samsa']  # HACK: SAMSA is too long to compute

--- a/easse/utils/resources.py
+++ b/easse/utils/resources.py
@@ -66,37 +66,3 @@ def download_ucca_model():
     config_json['vocab'] = str(UCCA_DIR / config_json['vocab'])
     with open(json_path, 'w') as f:
             json.dump(config_json, f)
-
-
-def get_turk_orig_sents(phase):
-    assert phase in ['valid', 'test']
-    if phase == 'valid':
-        phase = 'tune'
-    return read_lines(DATA_DIR / f'test_sets/turk/{phase}.8turkers.tok.norm')
-
-
-def get_turk_refs_sents(phase):
-    assert phase in ['valid', 'test']
-    if phase == 'valid':
-        phase = 'tune'
-    return [read_lines(DATA_DIR / f'test_sets/turk/{phase}.8turkers.tok.turk.{i}')
-            for i in range(8)]
-
-
-def get_pwkp_orig_sents(phase):
-    assert phase in ['valid', 'test']
-    return read_lines(DATA_DIR / f'test_sets/pwkp/pwkp.{phase}.src')
-
-
-def get_pwkp_refs_sents(phase):
-    assert phase in ['valid', 'test']
-    return [read_lines(DATA_DIR / f'test_sets/pwkp/pwkp.{phase}.dst')]
-
-
-def get_hsplit_orig_sents():
-    return get_turk_orig_sents(phase='test')[:70]
-
-
-def get_hsplit_refs_sents():
-    return [read_lines(DATA_DIR / f'test_sets/hsplit/hsplit.tok.{i+1}')
-            for i in range(4)]


### PR DESCRIPTION
Add option to use a custom test set:

Evaluate using:
```
easse evaluate -m "bleu,sari,fkgl" -q -t custom \
--orig_sents_path easse/resources/data/test_sets/turk/test.8turkers.tok.norm \
--refs_sents_paths easse/resources/data/test_sets/turk/test.8turkers.tok.turk.0,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.1,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.2,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.3,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.4,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.5,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.6,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.7 \
--sys_sents_path easse/resources/data/system_outputs/turk/lower/DMASS-DCSS.tok.low
```

Get the report using:
```
easse report -t custom \
--orig_sents_path easse/resources/data/test_sets/turk/test.8turkers.tok.norm \
--refs_sents_paths easse/resources/data/test_sets/turk/test.8turkers.tok.turk.0,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.1,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.2,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.3,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.4,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.5,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.6,easse/resources/data/test_sets/turk/test.8turkers.tok.turk.7 \
--sys_sents_path easse/resources/data/system_outputs/turk/lower/DMASS-DCSS.tok.low
```