### PR TITLE
Multiple systems report

### DIFF
--- a/easse/cli.py
+++ b/easse/cli.py
@@ -145,11 +145,16 @@ def evaluate_system_output(
 @cli.command('report')
 @common_options
 @click.option('--sys_sents_path', type=click.Path(), default=None,
-            help='Path to the system predictions input file that is to be evaluated.')
+            help='Path to the system predictions input file that is to be evaluated. You can also input a comma-separated list of files to compare multiple systems.')
 @click.option('--report_path', '-p', type=click.Path(), default='easse_report.html',
               help='Path to the output HTML report.')
 def _report(*args, **kwargs):
-    report(*args, **kwargs)
+    if kwargs['sys_sents_path'] is not None and len(kwargs['sys_sents_path'].split(',')) > 1:
+        # If we got multiple systems as input, split the paths and rename the key
+        kwargs['sys_sents_paths'] = kwargs.pop('sys_sents_path').split(',')
+        multiple_systems_report(*args, **kwargs)
+    else:
+        report(*args, **kwargs)
 
 
 def report(
@@ -173,23 +178,12 @@ def report(
             )
 
 
-@cli.command('multiple_systems_report')
-@common_options
-@click.option('--sys_sents_paths', type=click.Path(), required=True,
-            help='Comma separated list of paths to the systems predictions input files that are to be evaluated.')
-@click.option('--report_path', '-p', type=click.Path(), default='multiple_systems_easse_report.html',
-              help='Path to the output HTML report.')
-def _multiple_systems_report(*args, **kwargs):
-    kwargs['sys_sents_paths'] = kwargs['sys_sents_paths'].split(',')
-    return multiple_systems_report(*args, **kwargs)
-
-
 def multiple_systems_report(
         test_set,
         sys_sents_paths,
         orig_sents_path=None,
         refs_sents_paths=None,
-        report_path='multiple_systems_easse_report.html',
+        report_path='easse_report.html',
         tokenizer='13a',
         metrics=','.join(DEFAULT_METRICS)
         ):

--- a/easse/cli.py
+++ b/easse/cli.py
@@ -141,7 +141,7 @@ def evaluate_system_output(
 
 @cli.command('report')
 @common_options
-@click.option('--report_path', '-p', type=click.Path(), default='report.html',
+@click.option('--report_path', '-p', type=click.Path(), default='easse_report.html',
               help='Path to the output HTML report.')
 def _report(*args, **kwargs):
     report(*args, **kwargs)
@@ -152,7 +152,7 @@ def report(
         sys_sents_path=None,
         orig_sents_path=None,
         refs_sents_paths=None,
-        report_path='report.html',
+        report_path='easse_report.html',
         tokenizer='13a',
         metrics=','.join(DEFAULT_METRICS)
         ):
@@ -162,6 +162,6 @@ def report(
     orig_sents, sys_sents, refs_sents = get_sents(test_set, orig_sents_path, sys_sents_path, refs_sents_paths)
     lowercase = is_test_set_lowercase(test_set)
     write_html_report(
-            report_path, orig_sents, sys_sents, refs_sents, test_set_name=test_set,
+            report_path, orig_sents, sys_sents, refs_sents, test_set=test_set,
             lowercase=lowercase, tokenizer=tokenizer, metrics=metrics,
             )

--- a/easse/quality_estimation.py
+++ b/easse/quality_estimation.py
@@ -24,7 +24,7 @@ def corpus_quality_estimation(orig_sentences: List[str], sys_sentences: List[str
             'Compression ratio': get_average(get_compression_ratio, orig_sentences, sys_sentences),
             'Sentence splits': get_average(count_sentence_splits, orig_sentences, sys_sentences),
             'Levenshtein similarity': get_average(get_levenshtein_similarity, orig_sentences, sys_sentences),
-            'Exact matches': get_average(is_exact_match, orig_sentences, sys_sentences),
+            'Exact copies': get_average(is_exact_match, orig_sentences, sys_sentences),
             'Additions proportion': get_average(get_additions_proportion, orig_sentences, sys_sentences),
             'Deletions proportion': get_average(get_deletions_proportion, orig_sentences, sys_sentences),
             'Lexical complexity score': get_average(

--- a/easse/report.py
+++ b/easse/report.py
@@ -82,7 +82,7 @@ def get_random_html_id():
     return 'a' + html_id[1:]  # HTML id can't start with a number
 
 
-def get_qualitative_html_examples(orig_sents, sys_sents, refs_sents):
+def get_qualitative_examples_html(orig_sents, sys_sents, refs_sents):
     title_key_print = [
         ('Randomly sampled simplifications',
          lambda c, s, refs: 0,
@@ -345,6 +345,33 @@ def get_table_html(header, rows, row_names=None):
     return doc.getvalue()
 
 
+def get_score_table_html_single_system(orig_sents, sys_sents, refs_sents, lowercase, tokenizer, metrics):
+    return get_score_table_html_multiple_systems(orig_sents, [sys_sents], refs_sents, ['System output'], lowercase, tokenizer, metrics)
+
+
+def get_score_table_html_multiple_systems(orig_sents, sys_sents_list, refs_sents, system_names, lowercase, tokenizer, metrics):
+    doc = Doc()
+    sys_scores_list = [get_all_scores(orig_sents, sys_sents, refs_sents, lowercase=lowercase, tokenizer=tokenizer, metrics=metrics)
+                       for sys_sents in sys_sents_list]
+    # We evaluate the first reference against all the others (the second reference is duplicated to have the same number of reference as for systems).
+    # TODO: Ideally the system and references should be evaluated with exactly the same number of references.
+    ref_scores = get_all_scores(orig_sents, refs_sents[0], [refs_sents[1]] + refs_sents[1:],
+                                lowercase=lowercase, tokenizer=tokenizer, metrics=metrics)
+    assert all([sys_scores.keys() == ref_scores.keys() for sys_scores in sys_scores_list])
+    doc.asis(get_table_html(
+            header=list(ref_scores.keys()),
+            rows=[sys_scores.values() for sys_scores in sys_scores_list] + [ref_scores.values()],
+            row_names=system_names + ['Reference*'],
+            ))
+    doc.line(
+        'p',
+        klass='text-muted',
+        text_content=('* The Reference row represents one of the references (picked randomly) evaluated'
+                      ' against the others.'),
+    )
+    return doc.getvalue()
+
+
 def get_html_report(orig_sents: List[str], sys_sents: List[str], refs_sents: List[List[str]], test_set: str,
                     lowercase: bool = False, tokenizer: str = '13a', metrics: List[str] = DEFAULT_METRICS):
     doc = Doc()
@@ -369,23 +396,7 @@ def get_html_report(orig_sents: List[str], sys_sents: List[str], refs_sents: Lis
             with doc.tag('div', klass='container-fluid'):
                 doc.line('h3', 'System vs. Reference')
                 doc.stag('hr')
-                sys_scores = get_all_scores(orig_sents, sys_sents, refs_sents,
-                                            lowercase=lowercase, tokenizer=tokenizer, metrics=metrics)
-                # TODO: The system and references should be evaluated with the same number of references
-                ref_scores = get_all_scores(orig_sents, refs_sents[0], refs_sents[1:],
-                                            lowercase=lowercase, tokenizer=tokenizer, metrics=metrics)
-                assert sys_scores.keys() == ref_scores.keys()
-                doc.asis(get_table_html(
-                        header=list(sys_scores.keys()),
-                        rows=[sys_scores.values(), ref_scores.values()],
-                        row_names=['System output', 'Reference*'],
-                        ))
-                doc.line(
-                    'p',
-                    klass='text-muted',
-                    text_content=('* The Reference row represents one of the references (picked randomly) evaluated'
-                                  ' against the others.'),
-                )
+                doc.asis(get_score_table_html_single_system(orig_sents, sys_sents, refs_sents, lowercase, tokenizer, metrics))
                 doc.line('h3', 'By sentence length (characters)')
                 doc.stag('hr')
                 doc.asis(get_scores_by_length_html(orig_sents, sys_sents, refs_sents))
@@ -396,10 +407,115 @@ def get_html_report(orig_sents: List[str], sys_sents: List[str], refs_sents: Lis
             doc.line('h2', 'Qualitative evaluation')
             doc.stag('hr')
             with doc.tag('div', klass='container-fluid'):
-                doc.asis(get_qualitative_html_examples(orig_sents, sys_sents, refs_sents))
+                doc.asis(get_qualitative_examples_html(orig_sents, sys_sents, refs_sents))
     return indent(doc.getvalue())
 
 
 def write_html_report(filepath, *args, **kwargs):
     with open(filepath, 'w') as f:
         f.write(get_html_report(*args, **kwargs) + '\n')
+
+
+def get_multiple_systems_qualitative_examples_html(orig_sents, sys_sents_list, refs_sents, system_names):
+    title_key_print = [
+        ('Randomly sampled simplifications',
+         lambda c, s, refs: 0,
+         lambda value: ''),
+    ] + [
+        (f'Best simplifications according to SARI for {system_names[i]}',
+         lambda c, sys_sents, refs: -corpus_sari([c], [sys_sents[i]], [refs]),
+         lambda value: f'SARI={-value:.2f}')
+        for i in range(len(system_names))
+    ]
+
+    def get_one_sample_html(orig_sent, sys_sents, ref_sents, system_names, sort_key, print_func):
+        def get_one_sentence_html(sentence, system_name):
+            doc = Doc()
+            with doc.tag('div', klass='row'):
+                with doc.tag('div', klass='col-1'):
+                    doc.text(system_name)
+                with doc.tag('div', klass='col'):
+                    doc.asis(sentence)
+            return doc.getvalue()
+
+        doc = Doc()
+        with doc.tag('div', klass='mb-2 p-1'):
+            # Sort key
+            with doc.tag('div', klass='text-muted small'):
+                doc.asis(print_func(sort_key(orig_sent, sys_sents, ref_sents)))
+            with doc.tag('div', klass='ml-2'):
+                # Source
+                with doc.tag('div'):
+                    doc.asis(get_one_sentence_html(orig_sent, 'Original'))
+                # Predictions
+                    for sys_sent, system_name in zip(sys_sents, system_names):
+                        _, sys_sent_bold = make_differing_words_bold(orig_sent, sys_sent, make_text_bold_html)
+                        doc.asis(get_one_sentence_html(sys_sent_bold, system_name))
+                # References
+                collapse_id = get_random_html_id()
+                with doc.tag('div', klass='position-relative'):
+                    with doc.tag('a', ('data-toggle', 'collapse'), ('href', f'#{collapse_id}'),
+                                 klass='stretched-link small'):
+                        doc.text('References')
+                    with doc.tag('div', klass='collapse', id=collapse_id):
+                        for ref_sent in refs:
+                            _, ref_sent_bold = make_differing_words_bold(orig_sent, ref_sent, make_text_bold_html)
+                            with doc.tag('div', klass='text-muted'):
+                                doc.asis(ref_sent_bold)
+        return doc.getvalue()
+
+    doc = Doc()
+    for title, sort_key, print_func in title_key_print:
+        with doc.tag('div', klass='container-fluid mt-4 p-2 border'):
+            collapse_id = get_random_html_id()
+            with doc.tag('a', ('data-toggle', 'collapse'), ('href', f'#{collapse_id}')):
+                doc.line('h3', klass='m-2', text_content=title)
+            # Now lets print the examples
+            sample_generator = sorted(
+                    zip(orig_sents, zip(*sys_sents_list), zip(*refs_sents)),
+                    key=lambda args: sort_key(*args),
+            )
+            # Samples displayed by default
+            with doc.tag('div', klass='collapse', id=collapse_id):
+                n_samples = 50
+                for i, (orig_sent, sys_sents, refs) in enumerate(sample_generator):
+                    if i >= n_samples:
+                        break
+                    doc.asis(get_one_sample_html(orig_sent, sys_sents, refs, system_names, sort_key, print_func))
+    return doc.getvalue()
+
+
+def get_multiple_systems_html_report(orig_sents, sys_sents_list, refs_sents, system_names, test_set, lowercase, tokenizer, metrics):
+    doc = Doc()
+    doc.asis('<!doctype html>')
+    with doc.tag('html', lang='en'):
+        doc.asis(get_head_html())
+        with doc.tag('body', klass='container-fluid m-2 mb-5'):
+            doc.line('h1', 'EASSE report', klass='mt-4')
+            with doc.tag('a', klass='btn btn-link', href='https://forms.gle/J8KVkJsqYe8GvYW46'):
+                doc.text('Any feedback welcome!')
+            doc.stag('hr')
+            doc.line('h2', 'Test set')
+            doc.stag('hr')
+            with doc.tag('div', klass='container-fluid'):
+                doc.asis(get_test_set_description_html(
+                    test_set=test_set,
+                    orig_sents=orig_sents,
+                    refs_sents=refs_sents,
+                ))
+            doc.line('h2', 'Scores')
+            doc.stag('hr')
+            with doc.tag('div', klass='container-fluid'):
+                doc.line('h3', 'System vs. Reference')
+                doc.stag('hr')
+                doc.asis(get_score_table_html_multiple_systems(orig_sents, sys_sents_list, refs_sents, system_names, lowercase, tokenizer, metrics))
+            doc.line('h2', 'Qualitative evaluation')
+            doc.stag('hr')
+            with doc.tag('div', klass='container-fluid'):
+                doc.asis(get_multiple_systems_qualitative_examples_html(orig_sents, sys_sents_list, refs_sents, system_names))
+    return indent(doc.getvalue())
+
+
+def write_multiple_systems_html_report(filepath, *args, **kwargs):
+    with open(filepath, 'w') as f:
+        f.write(get_multiple_systems_html_report(*args, **kwargs) + '\n')


### PR DESCRIPTION
Add option to compare multiple systems in a html report when multiple files are sent to `--sys_sents_path`.


For example:
```
easse report -t turkcorpus_test --sys_sents_path easse/resources/data/system_outputs/turkcorpus/test/lower/ACCESS.tok.low,easse/resources/data/system_outputs/turkcorpus/test/lower/Hybrid.tok.low
```
<img width="1243" alt="Screenshot 2020-03-11 at 20 00 29" src="https://user-images.githubusercontent.com/12654189/76453351-074da600-63d3-11ea-9005-eac274ed6b87.png">
