### PR TITLE
Legacy and backward compatibility

### DIFF
--- a/easse/cli.py
+++ b/easse/cli.py
@@ -127,6 +127,9 @@ def evaluate_system_output(
     if 'sari' in metrics:
         metrics_scores["sari"] = corpus_sari(orig_sents, sys_sents, refs_sents, tokenizer=tokenizer, lowercase=lowercase)
 
+    if 'sari_legacy' in metrics:
+        metrics_scores["sari_legacy"] = corpus_sari(orig_sents, sys_sents, refs_sents, tokenizer=tokenizer, lowercase=lowercase, legacy=True)
+
     if 'samsa' in metrics:
         metrics_scores["samsa"] = corpus_samsa(orig_sents, sys_sents, tokenizer=tokenizer, verbose=True, lowercase=lowercase)
 

--- a/easse/utils/constants.py
+++ b/easse/utils/constants.py
@@ -48,6 +48,6 @@ SYSTEM_OUTPUTS_DIRS_MAP = {
 VALID_TEST_SETS = ['turkcorpus_test', 'turkcorpus_valid','turkcorpus_test_legacy', 'turkcorpus_valid_legacy',
                    'pwkp_test', 'pwkp_valid', 'hsplit_test', 'wikisplit_test', 'wikisplit_valid', 'asset_test',
                    'asset_valid', 'googlecomp_test', 'googlecomp_valid', 'custom']
-VALID_METRICS = ['bleu', 'sari', 'samsa', 'fkgl', 'sent_bleu', 'f1_token']
+VALID_METRICS = ['bleu', 'sari', 'samsa', 'fkgl', 'sent_bleu', 'f1_token', 'sari_legacy']
 DEFAULT_METRICS = [m for m in VALID_METRICS if m not in ['samsa', 'sent_bleu', 'f1_token']]
 # HACK: Only simplification-specific metrics, but SAMSA which is too long to compute

--- a/easse/utils/resources.py
+++ b/easse/utils/resources.py
@@ -4,6 +4,7 @@ import sys
 import tarfile
 import time
 from urllib.request import urlretrieve
+import warnings
 import zipfile
 
 from easse.utils.constants import STANFORD_CORENLP_DIR, UCCA_DIR, UCCA_PARSER_PATH, TEST_SETS_PATHS, SYSTEM_OUTPUTS_DIRS_MAP
@@ -60,7 +61,7 @@ def update_ucca_path():
         config_json = json.load(f)
     config_json['vocab'] = str(UCCA_DIR / 'vocab/en_core_web_lg.csv')
     with open(json_path, 'w') as f:
-            json.dump(config_json, f)
+        json.dump(config_json, f)
 
 
 def download_ucca_model():
@@ -72,11 +73,26 @@ def download_ucca_model():
     update_ucca_path()
 
 
+def maybe_map_deprecated_test_set_to_new_test_set(test_set):
+    '''Map deprecated test sets to new test sets'''
+    deprecated_test_sets_map = {
+            'turk': 'turkcorpus_test',
+            'turk_valid': 'turkcorpus_valid',
+    }
+    if test_set in deprecated_test_sets_map:
+        deprecated_test_set = test_set
+        test_set = deprecated_test_sets_map[deprecated_test_set]
+        warnings.warn(f'"{deprecated_test_set}" test set is deprecated. Please use "{test_set}" instead.')
+    return test_set
+
+
 def get_orig_sents(test_set):
+    test_set = maybe_map_deprecated_test_set_to_new_test_set(test_set)
     return read_lines(TEST_SETS_PATHS[(test_set, 'orig')])
 
 
 def get_refs_sents(test_set):
+    test_set = maybe_map_deprecated_test_set_to_new_test_set(test_set)
     return [read_lines(ref_sents_path) for ref_sents_path in TEST_SETS_PATHS[(test_set, 'refs')]]
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='easse',
-    version='0.2',
+    version='0.2.1',
     description='Easier Automatic Sentence Simplification Evaluation',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
We introduced breaking changes in EASSE which caused some problems: https://github.com/facebookresearch/access/issues/10

This PR includes:
- Fix backward compatibility for test set names
- Add sari_legacy as a metric
- Bump version to 0.2.1
