### PR TITLE
Fix package setting for poetry

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include easse/resources/data *
+prune **/system_outputs/**

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ tqdm>=4.32.2
 yattag
 plotly>=4.0.0
 bert_score
-tseval@ git+https://github.com/facebookresearch/text-simplification-evaluation.git
-simalign@ git+https://github.com/cisnlp/simalign.git
+tseval@ git+https://github.com/facebookresearch/text-simplification-evaluation.git@main
+simalign


### PR DESCRIPTION
This PR includes two commits and enables use of a python dependency managemer [poetry](https://github.com/python-poetry/poetry) like this in other projects.

```bash
poetry add 'git+https://github.com/feralvam/easse'
```

## Fix of requirements.txt

Update requirements.txt to refer the renamed branch `main` of [tseval](https://github.com/facebookresearch/text-simplification-evaluation) and use simalign in [pypi](https://pypi.org/project/simalign/).


## Fix of MANIFEST.in

With only change of ``requirements.txt``, it fails to add easse with the following error message, beacucse ``asset`` is a symbolic link.

```
    error: can't copy 'easse/resources/data/system_outputs/asset': doesn't exist or not a regular file
```