### PR TITLE
Fixes issues with failed downloads

### DIFF
--- a/easse/utils/helpers.py
+++ b/easse/utils/helpers.py
@@ -2,6 +2,8 @@ from typing import List
 from pathlib import Path
 import tempfile
 
+def safe_divide(a,b):
+    return a/b if b else 0
 
 def get_temp_filepath(create=False):
     temp_filepath = Path(tempfile.mkstemp()[1])

--- a/easse/utils/resources.py
+++ b/easse/utils/resources.py
@@ -14,8 +14,7 @@ from easse.utils.constants import (
     TEST_SETS_PATHS,
     SYSTEM_OUTPUTS_DIRS_MAP,
 )
-from easse.utils.helpers import get_temp_filepath, read_lines
-
+from easse.utils.helpers import get_temp_filepath, read_lines, safe_divide
 
 def reporthook(count, block_size, total_size):
     # Download progress bar
@@ -25,7 +24,7 @@ def reporthook(count, block_size, total_size):
         return
     duration = time.time() - start_time
     progress_size_mb = count * block_size / (1024 * 1024)
-    speed = progress_size_mb / duration
+    speed = safe_divide(progress_size_mb, duration)
     percent = int(count * block_size * 100 / total_size)
     msg = f'\r... {percent}% - {int(progress_size_mb)} MB - {speed:.2f} MB/s - {int(duration)}s'
     sys.stdout.write(msg)
@@ -54,7 +53,7 @@ def untar(compressed_path, output_dir):
 
 def download_stanford_corenlp():
     url = 'http://nlp.stanford.edu/software/stanford-corenlp-full-2018-10-05.zip'
-    temp_filepath = get_temp_filepath()
+    temp_filepath = get_temp_filepath(create=True)
     download(url, temp_filepath)
     STANFORD_CORENLP_DIR.mkdir(parents=True, exist_ok=True)
     unzip(temp_filepath, STANFORD_CORENLP_DIR.parent)
@@ -72,7 +71,7 @@ def update_ucca_path():
 
 def download_ucca_model():
     url = 'https://github.com/huji-nlp/tupa/releases/download/v1.3.10/ucca-bilstm-1.3.10.tar.gz'
-    temp_filepath = get_temp_filepath()
+    temp_filepath = get_temp_filepath(create=True)
     download(url, temp_filepath)
     UCCA_DIR.mkdir(parents=True, exist_ok=True)
     untar(temp_filepath, UCCA_DIR)


### PR DESCRIPTION
Existing code fails when the global variable `start_time` is equal to `time.time()`. In addition, not setting the flag `create=True` in `get_temp_filepath()` causes the temporary file to be closed before it can be used. This pull request fixes both errors and allows both the `ucca_model` and `stanford_corenlp` to be downloaded successfully.