### PR TITLE
Fix RuntimeError during BLEU calculation

### DIFF
--- a/easse/report.py
+++ b/easse/report.py
@@ -286,7 +286,7 @@ def get_scores_by_length_html(
         sents = np.array(sents)
         sents_by_bin = []
         for sent_indexes in bins:
-            sents_by_bin.append(np.array(sents)[sent_indexes])
+            sents_by_bin.append(np.array(sents)[sent_indexes].tolist())
         return sents_by_bin
 
     intervals = get_equally_populated_intervals(orig_sents, n_bins)


### PR DESCRIPTION
When calculating metrics over length-bins, `easse report` fails with following error: 

```
RuntimeError: BLEU: Each element of `refs` should be a sequence of strings.
```

This PR converts input/reference/output sentences to plain Python lists before passing them to BLEU evaluation routines.

## Attachments

To reproduce:

```
conda create -n easse python=3.9
conda activate easse
pip install -e .

head -n 50 easse/resources/data/test_sets/asset/asset.test.orig > test.orig
head -n 50 easse/resources/data/test_sets/asset/asset.test.simp.0 > test.ref
head -n 50 easse/resources/data/system_outputs/asset/test/tok/ACCESS.tok > test.sys

easse evaluate \
    -m "bleu,sari,fkgl" \
    --orig_sents_path test.orig \
    --refs_sents_paths test.ref \
    --sys_sents_path test.sys \
    -t custom

easse report \
    -m "bleu,sari,fkgl" \
    --orig_sents_path test.orig \
    --refs_sents_paths test.ref \
    --sys_sents_path test.sys \
    -t custom \
    --report_path report.html
```

<details>
<summary>Full traceback</summary>

```
Traceback (most recent call last):
  File "/usr/local/Caskroom/miniconda/base/envs/easse/bin/easse", line 33, in <module>
    sys.exit(load_entry_point('easse', 'console_scripts', 'easse')())
  File "/usr/local/Caskroom/miniconda/base/envs/easse/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/Caskroom/miniconda/base/envs/easse/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/Caskroom/miniconda/base/envs/easse/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/Caskroom/miniconda/base/envs/easse/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/Caskroom/miniconda/base/envs/easse/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/jantrienes/github/easse/easse/cli.py", line 278, in _report
    report(*args, **kwargs)
  File "/Users/jantrienes/github/easse/easse/cli.py", line 296, in report
    write_html_report(
  File "/Users/jantrienes/github/easse/easse/report.py", line 480, in write_html_report
    f.write(get_html_report(*args, **kwargs) + '\n')
  File "/Users/jantrienes/github/easse/easse/report.py", line 466, in get_html_report
    doc.asis(get_scores_by_length_html(orig_sents, sys_sents, refs_sents))
  File "/Users/jantrienes/github/easse/easse/report.py", line 305, in get_scores_by_length_html
    row = get_all_scores(
  File "/Users/jantrienes/github/easse/easse/report.py", line 32, in get_all_scores
    scores['BLEU'] = corpus_bleu(sys_sents, refs_sents, force=True, tokenize=tokenizer, lowercase=lowercase).score
  File "/usr/local/Caskroom/miniconda/base/envs/easse/lib/python3.9/site-packages/sacrebleu/compat.py", line 35, in corpus_bleu
    return metric.corpus_score(hypotheses, references)
  File "/usr/local/Caskroom/miniconda/base/envs/easse/lib/python3.9/site-packages/sacrebleu/metrics/base.py", line 418, in corpus_score
    self._check_corpus_score_args(hypotheses, references)
  File "/usr/local/Caskroom/miniconda/base/envs/easse/lib/python3.9/site-packages/sacrebleu/metrics/base.py", line 258, in _check_corpus_score_args
    raise RuntimeError(f'{prefix}: {err_msg}')
RuntimeError: BLEU: Each element of `refs` should be a sequence of strings.
```

</details>