### PR TITLE
Use scikit-learn instead of sklearn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ requests>=2.21.0
 sacrebleu>=2.0.0
 sacremoses
 seaborn
-sklearn
+scikit-learn
 stanfordnlp
 tqdm>=4.32.2
 yattag


### PR DESCRIPTION
The 'sklearn' PyPI package is deprecated.

https://pypi.org/project/sklearn/